### PR TITLE
Add Laravel 5.8.x to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=7",
-    "laravel/framework": "5.5.x|5.6.x|5.7.x",
+    "laravel/framework": "5.5.x|5.6.x|5.7.x|5.8.x",
     "phpro/soap-client": "^0.7.7"
   },
   "autoload": {


### PR DESCRIPTION
TendoPay is planning to update Laravel 5.7 to 5.8 
DragonPay plugin looks enough to be ready for Laravel 5.8.
So we would like to add  5.8.x in the composer.json